### PR TITLE
Correct URL for Hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the source code for [SerbianEntrepreneurs.com](https://serbianentreprene
 
 ## Running a Development server
 
-This site is built using [Hugo](http://gethugo.io).
+This site is built using [Hugo](http://gohugo.io).
 
 ```
 # Install Hugo first using Brew or Apt


### PR DESCRIPTION
The original URL is dead. This one isn't.

(I know this is a really tiny diff for my first PR in this repo, but hopefully the next one I do sometime soon will actually deal with the website itself, not the documentation. 😊)